### PR TITLE
fix: show EditorBubbleMenu only if the editor isEditable

### DIFF
--- a/src/lib/ui/editor/index.svelte
+++ b/src/lib/ui/editor/index.svelte
@@ -160,7 +160,7 @@
 	});
 </script>
 
-{#if editor}
+{#if editor && editor.isEditable}
 	<EditorBubbleMenu {editor} />
 {/if}
 


### PR DESCRIPTION
EditorBubbleMenu should not be visible if editor is disabled by the editable prop passed to editorProps.